### PR TITLE
Update homepage_en.html

### DIFF
--- a/src/assets/homepage/homepage_en.html
+++ b/src/assets/homepage/homepage_en.html
@@ -13,7 +13,7 @@
           <div>
               <h3>What am I searching?</h3>
               <p>Search Our Collections provides one search for books and e-books, journals and articles, databases, media and more, available in the library and online. <a href="https://libguides.mit.edu/search-our-collections">Learn more about Search Our Collections</a>.</p>
-              <p>If you want to limit your search to materials available in the library, choose “Library catalog only” from the "All" drop-down menu in the search box.</p>
+              <p>If you want to limit your search to materials available in the library, choose “MIT library catalog” from the "All" drop-down menu in the search box.</p>
           </div>
           <div>
           <h3>Other specialized search tools</h3>


### PR DESCRIPTION
### Why these changes are being introduced

I noticed a mismatch between our 'MIT library catalog' search profile name and how the homepage content refers to it.

### How this addresses that need

updates homepage content to use 'MIT library catalog' to refer to this search profile, correctly matching
the actual display name of the search profile.

### Side effects of this change

None

