### PR TITLE
NDE-92: Updating key buttons and links to match design system styling (and be more noticeable)

### DIFF
--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -621,6 +621,11 @@ nde-record-availability {
 
 
 // RESULT PAGE
+// Remove underline of result titles on result page
+nde-full-display-container nde-record-title h3 a {
+    text-decoration: none !important;
+}
+
 // Updating buttons to DS styles
 nde-request-card mat-card-actions{
     button {

--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -684,6 +684,10 @@ nde-location .getit-location-card button {
     span{
         color: $color-text-primary !important;
         font-weight: 400 !important;
+
+        &:hover {
+            color: $color-blue-500 !important;
+        }
     }
     
 }

--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -62,6 +62,18 @@ html {
   }
 }
 
+@mixin underlinedSubtleLinks {
+  color: $color-text-primary !important;
+  text-decoration: underline !important;
+  text-decoration-color: $color-gray-300 !important;
+  text-underline-offset: 0.25rem !important;  
+
+  &:hover {
+    color: $color-blue-500 !important;
+    text-decoration-color: $color-blue-500 !important;
+  }
+}
+
 @mixin underlinedNavLinks {
   color: $color-white;
   text-decoration: underline;
@@ -538,6 +550,18 @@ nde-quick-filters {
 
 }
 
+// Filter row styliing
+// All filters button
+div.filters-container #allFilterToggleButton {
+    @include overrideLinksToLinks();
+}
+
+// Sort by dropdown link styling
+div.filters-container button[aria-label="Sort by Relevance"] {
+    @include overrideLinksToLinks();
+}
+
+
 // Title styling 
 nde-record-title {
     a {
@@ -626,6 +650,44 @@ nde-location-item-service-button {
     }
 }
 
+nde-login {
+    button {
+        @include overrideButtonsToLinks;
+    }
+}
+
+// Styling accordion content links
+mat-expansion-panel .mat-expansion-panel-content .mat-expansion-panel-body {
+    a {
+        @include underlinedSubtleLinks;
+    }
+}
+
+nde-view-it-section button.view-it-card-no-license-container .icon-and-link-container {
+    @include overrideButtonsToLinks;
+    h5 {
+        color: $color-text-primary !important;
+
+        &:hover {
+            color: $color-blue-500 !important;
+        }
+    }
+}
+
+button[data-qa="view-it-section-show-more-or-show-less"] {
+    @include overrideButtonsToLinks;
+}
+
+nde-location .getit-location-card button {
+    @include overrideButtonsToLinks;
+
+    span{
+        color: $color-text-primary !important;
+        font-weight: 400 !important;
+    }
+    
+}
+
 // Natural Language Search Icon color override
 mat-icon[data-mat-icon-name="natural-language-search"] {
     path {
@@ -634,6 +696,11 @@ mat-icon[data-mat-icon-name="natural-language-search"] {
 }
 
 // CITATION SEARCH PAGE
+// Reset Form button
+form .buttons-container-wrapper button[data-qa="reset button"] {
+    @include overrideLinksToLinks();
+}
+
 // Submit button
 form .buttons-container-wrapper button[type="submit"] {
     @include secondaryButton;
@@ -643,6 +710,17 @@ form .buttons-container-wrapper button[type="submit"] {
         border-color: $color-gray-400 !important;
         color: $color-gray-400 !important;
     }
+}
+
+// JOURNAL SEARCH PAGE
+nde-journal-database-layout-component {
+    padding-bottom: 40px;
+}
+
+// Category list links
+nde-categories mat-tree-node {
+    @include underlinedLinks();
+    color: $color-text-primary !important;
 }
 
 // MY LIBRARY ACTIVITY PAGE (under profile when logged in)


### PR DESCRIPTION
### Why these changes are being introduced
We've previously gone through the UI and made some buttons and links match our new design system styling. There were many more links we've since noticed that needed updating.

### How this addresses that need
This work updates buttons and links to match design system styling on:
* The filter row above search results
* The results page accordion content
* The citation search page "reset form" button
* The journals page category list

Along the way I found a few small bugs to fix:
* Results titles on full record pages weren't links but looked like links. This has been fixed.
* Added some space below the journals page content to fix a lack of spacing.

#### Before/After screenshots:
<img width="1062" height="923" alt="Screenshot 2026-04-16 at 9 14 34 AM" src="https://github.com/user-attachments/assets/c44fff04-4efd-4d8e-b7ba-04669e543d26" />
<img width="1090" height="922" alt="Screenshot 2026-04-16 at 9 10 11 AM" src="https://github.com/user-attachments/assets/045dcb74-4970-47cb-a920-92393ea31a9a" />

<img width="308" height="708" alt="Screenshot 2026-04-16 at 9 14 59 AM" src="https://github.com/user-attachments/assets/82d73a51-539a-4ac8-9e91-614360c1c17d" />
<img width="308" height="721" alt="Screenshot 2026-04-16 at 9 05 53 AM" src="https://github.com/user-attachments/assets/50ec888b-ac7f-4750-8200-b32212c80d9c" />

<img width="250" height="88" alt="Screenshot 2026-04-16 at 9 15 19 AM" src="https://github.com/user-attachments/assets/fc36a1c5-70e4-43cb-9cb6-34432b3266a7" />
<img width="705" height="170" alt="Screenshot 2026-04-16 at 8 43 45 AM" src="https://github.com/user-attachments/assets/c53e7602-1869-4971-a6c2-deaef6d1c2b3" />


<img width="1388" height="60" alt="Screenshot 2026-04-16 at 9 15 10 AM" src="https://github.com/user-attachments/assets/f8deb8c7-ee90-42bd-a436-19e4f9fb3cd2" />
<img width="1408" height="95" alt="Screenshot 2026-04-16 at 8 50 19 AM" src="https://github.com/user-attachments/assets/ddc9301b-a370-4375-ab87-d53bd606a96e" />




### Side effects of this change
None observed, but would be good to check!

### Relevant ticket(s)
https://mitlibraries.atlassian.net/browse/NDE-92
