### PR TITLE
Quick fix to hide H1 alongside H2 in search box

### DIFF
--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -369,8 +369,10 @@ div.search-container, nde-search-box-presenter {
         .background-overlay { background-color: $color-black !important;}        
     }
 
-    .custom-search-bar-container > h2 {
-        display: none;
+    .custom-search-bar-container {
+        > h1, > h2 {
+            display: none;
+        } 
     }
     
     .search_box_container {gap: 4px;}


### PR DESCRIPTION
### Why these changes are being introduced
A recent markup change by the Primo team led an H1 to appear where we had previously hidden an H2

<img width="1289" height="319" alt="Screenshot 2026-04-21 at 9 23 23 AM" src="https://github.com/user-attachments/assets/bf65b069-77b9-4bb6-bae2-5cd4d2e91555" />

### How this addresses that need
This work includes both H1 and H2 to be hidden inside the search box at the top of the screen.

<img width="1338" height="251" alt="Screenshot 2026-04-21 at 3 10 12 PM" src="https://github.com/user-attachments/assets/0418426e-6759-4bd6-8f9a-5a17f8fe703f" />

### Side effects of this change
n/a

### Relevant ticket(s)
n/a
