### PR TITLE
Add GitHub Actions workflow to run tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test -- --no-watch --browsers=ChromeHeadless --reporters=verbose
+        run: npm test -- --no-watch --browsers=ChromeHeadless

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,14 @@ name: Run Tests
 on:
   push:
 
+permissions:
+   contents: read
+
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -14,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --no-watch --no-progress --browsers=ChromeHeadless

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test -- --no-watch --no-progress --browsers=ChromeHeadless
+        run: npm test -- --no-watch --browsers=ChromeHeadless --reporters=verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,7 @@ name: Run Tests
 
 on:
   push:
-    branches:
-      - '**'
+
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
### Why these changes are being introduced

We want to make sure that tests are passing before new commits are merged into our production branch. 



### How this addresses that need
This pull request adds a new GitHub Actions workflow to automate testing for the project. The workflow is triggered on every push to any branch and sets up a Node.js environment, installs dependencies, and runs the test suite in a headless Chrome browser.

* Added `.github/workflows/test.yml` to configure a GitHub Actions workflow that installs Node.js 20, caches npm dependencies, installs project dependencies, and runs tests using ChromeHeadless on every push.

I think we need to configure branch protection rules to enforce that tests need to pass before a merge. This just sets up the workflow to run those tests.

### Side effects of this change

None

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/NDE-94
