### PR TITLE
Move natural language search button to the right of the advanced search button

### DIFF
--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -387,6 +387,10 @@ div.search-container, nde-search-box-presenter {
             display: none;
         } 
     }
+    // move natural language search button to the right of the advanced search button
+    button[data-qa="natural-language-search-button"] {
+    order: 1;
+    }
     
     .search_box_container {gap: 4px;}
 

--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -387,9 +387,10 @@ div.search-container, nde-search-box-presenter {
             display: none;
         } 
     }
+    
     // move natural language search button to the right of the advanced search button
     button[data-qa="natural-language-search-button"] {
-    order: 1;
+        order: 1;
     }
     
     .search_box_container {gap: 4px;}


### PR DESCRIPTION
### Why these changes are being introduced

We want to change the display order of the NLS and advanced search options in the main Primo NDE search area so that the advanced search button is closest to the search box, followed by the NLS button.

### How this addresses that need

adds CSS styles to explicitly sort the NLS button to display after (to the right of) the advanced search button 

### Side effects of this change
None

### Relevant ticket(s)
https://mitlibraries.atlassian.net/browse/NDE-134
https://mitlibraries.atlassian.net/browse/NDE-114

