### PR TITLE
Refine github actions workflow for development NDE customization package build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,20 +30,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Sanitize inputs
-        id: sanitize
-        env:
-          RAW_VIEW_ID: ${{ inputs.view_id }}
-        run: |
-          SANITIZED=$(echo "${RAW_VIEW_ID}" | tr -cd '[:alnum:]_-')
-          echo "view_id=${SANITIZED}" >> $GITHUB_OUTPUT
-
       - name: Build NDE customization package
         env:
           # Setting VIEW_ID here overrides the value in build-settings.env at build time.
           # dotenv does not overwrite variables already present in process.env (override: false by default),
           # so shell/CI env vars always take precedence over the .env file.
-          VIEW_ID: ${{ steps.sanitize.outputs.view_id }}
+          VIEW_ID: ${{ inputs.view_id }}
         run: npm run build
         
       - name: Upload NDE customization package
@@ -52,6 +44,6 @@ jobs:
         # taken from the filename (the name input is ignored when archive is false so is excluded in this step).
         uses: actions/upload-artifact@v7
         with:
-          path: dist/01MIT_INST-${{ steps.sanitize.outputs.view_id }}.zip
+          path: dist/01MIT_INST-${{ inputs.view_id }}.zip
           archive: false
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build NDE customization package
+name: Development Build for NDE customization package
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
       view_id:
         description: 'View ID (used to name the output zip)'
         required: true
-        default: 'NDE'
+        default: 'NDE_DEV'
 
 permissions:
   contents: read
@@ -40,18 +40,18 @@ jobs:
 
       - name: Build NDE customization package
         env:
+          # Setting VIEW_ID here overrides the value in build-settings.env at build time.
+          # dotenv does not overwrite variables already present in process.env (override: false by default),
+          # so shell/CI env vars always take precedence over the .env file.
           VIEW_ID: ${{ steps.sanitize.outputs.view_id }}
         run: npm run build
+        
       - name: Upload NDE customization package
+        # postbuild.js produces dist/01MIT_INST-<view_id>.zip alongside the unzipped folder.
+        # archive: false uploads that file as-is without re-zipping it; the artifact name is
+        # taken from the filename (the name input is ignored when archive is false so is excluded in this step).
         uses: actions/upload-artifact@v7
         with:
-          name: custom-module-dist
           path: dist/01MIT_INST-${{ steps.sanitize.outputs.view_id }}.zip
-          if-no-files-found: error
-
-      - name: Upload NDE customization package (unzipped)
-        uses: actions/upload-artifact@v7
-        with:
-          name: custom-module-dist-unzipped
-          path: dist/01MIT_INST-${{ steps.sanitize.outputs.view_id }}/
+          archive: false
           if-no-files-found: error


### PR DESCRIPTION
### Why these changes are being introduced:
* We plan to have other build workflows for production and staging, so renaming this workflow
to clarify it is for development.
* The default VIEW_ID should be NDE_DEV because this workflow is intended to be manually triggered
for testing and development purposes, and NDE_DEV is the most common view used for development and
testing.
* The build script already creates a .zip file, so we can upload that directly instead of having the
workflow re-zip the unzipped folder.

### How this addresses that need:
* Consolidate to a single upload step using archive: false to upload the .zip produced by postbuild.js directly, avoiding double-zipping
* Remove the redundant unzipped artifact upload step
* Rename workflow to clarify it is manually triggered
* Change default VIEW_ID from NDE to NDE_DEV
* Add inline comments explaining the dotenv precedence behavior and the archive: false artifact naming behavior

### Side effects of this change:
None

### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/NDE-95