### PR TITLE
Update homepage to use "Articles, Books & More"

### DIFF
--- a/src/assets/homepage/homepage_en.html
+++ b/src/assets/homepage/homepage_en.html
@@ -12,7 +12,7 @@
       <div class="column">
           <div>
               <h3>What am I searching?</h3>
-              <p>Search Our Collections provides one search for books and e-books, journals and articles, databases, media and more, available in the library and online. <a href="https://libguides.mit.edu/search-our-collections">Learn more about Search Our Collections</a>.</p>
+              <p>Articles, Books & More provides one search for books and e-books, journals and articles, databases, media and more, available in the library and online. <a href="https://libguides.mit.edu/search-our-collections">Learn more about Articles, Books & More</a>.</p>
               <p>If you want to limit your search to materials available in the library, choose “MIT library catalog” from the "All" drop-down menu in the search box.</p>
           </div>
           <div>


### PR DESCRIPTION

### Why these changes are being introduced
The branded name for Primo is changing from "Search our collections" to "Articles, Books & More".

### How this addresses that need:
Updates the text content on the home page to use the new branded
name for Primo, "Articles, Books & More" instead of "Search our collections".

### Side effects of this change:
none

### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/nde-138