### PR TITLE
Force to top Get it online section in full display

### DIFF
--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -827,3 +827,14 @@ section.no-results-content {
         color: $color-text-primary !important;       
     } 
 }
+
+// Full Record Page - Request Options Section
+/* Reorder full display accordion panels */
+mat-accordion[displaymode="flat"] {
+  display: flex !important;
+  flex-direction: column;
+}
+
+mat-accordion[displaymode="flat"] > [id="nui.getit.service_viewit"] {
+     order: -1; 
+}


### PR DESCRIPTION
### Why these changes are being introduced:
We want the Get it online section to always appear first in the accordian list on full display page followed by the find / request section and then the locations section.

In Primo NDE configuration the Get it online and locations section are considered the same section, so it isn't normally possible to put the Requests section between the Get it online and locations sections.

This change forces the Get it online section to the top of the full display, bumping the requests section to the second position, between the Get it online section and the locations section.

### How this addresses that need:
Adds styles to force the Get it online section to the top of the full display, above the locations and request sections.

### Side effects of this change:
Reordering the full display services in Primo NDE configuration will have no effect on the position of the Get it online section, which will always appear first in the full display.

### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/NDE-145