### PR TITLE
Primo homepage updates

### DIFF
--- a/src/assets/homepage/homepage_en.html
+++ b/src/assets/homepage/homepage_en.html
@@ -12,8 +12,8 @@
       <div class="column">
           <div>
               <h3>What am I searching?</h3>
-              <p>Articles, Books & More provides one search for books and e-books, journals and articles, databases, media and more, available in the library and online. <a href="https://libguides.mit.edu/search-our-collections">Learn more about Articles, Books & More</a>.</p>
-              <p>If you want to limit your search to materials available in the library, choose “MIT library catalog” from the "All" drop-down menu in the search box.</p>
+              <p>Articles, Books &amp; More provides one search for books and e-books, journals and articles, databases, media and more, available in the library and online. <a href="https://libguides.mit.edu/search-our-collections">Learn more about Articles, Books &amp; More</a>.</p>
+              <p>If you want to limit your search to materials available in the library, choose "Books &amp; media" from the "All" drop-down menu in the search box.</p>
           </div>
           <div>
           <h3>Other specialized search tools</h3>
@@ -22,7 +22,7 @@
                   <li><a href="http://archnet.org/">Archnet</a>: Architecture, design, and conservation issues related to the Muslim world.</li>
                   <li><a href="http://archivesspace.mit.edu/">ArchivesSpace</a>: Archives and manuscripts in our <a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a>.</li>
                   <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT</a>: MIT theses, articles and other research materials.</li>
-                  <li><a href="https://libraries.mit.edu/dome">Dome</a>: MIT Libraries’ digital collections – images, media, maps, and more.</li>
+                  <li><a href="https://libraries.mit.edu/dome">Dome</a>: MIT Libraries' digital collections - images, media, maps, and more.</li>
                   <li><a href="https://geodata.libraries.mit.edu/">GeoData</a>: GIS/spatial data available at MIT.</li>
                   <li><a href="https://libraries.mit.edu/experts">Subject guides</a>: Created by our librarians for targeted research by subject.</li>
               </ul>

--- a/src/assets/homepage/homepage_en.html
+++ b/src/assets/homepage/homepage_en.html
@@ -42,8 +42,7 @@
           </div>
           <div>
           <h3>Need help?</h3>
-              <p><a href="https://libraries.mit.edu/ask">Ask us</a>. Live chat is available M-F, 10am-5pm (excluding
-                  holidays), or you can email us any time.</p>
+              <p><a href="https://libraries.mit.edu/ask">Ask us</a> via chat or email.</p>
               <p>Not sure where to start? <a href="https://libraries.mit.edu/consultations">Request a research consultation</a> with one of our <a href="https://libraries.mit.edu/experts">expert librarians</a>.</p>
               <p>Find out about <a href="https://libraries.mit.edu/accessibility">accessibility at MIT Libraries</a>.</p>
           </div>    


### PR DESCRIPTION
### Why these changes are being introduced:
- We do not want to maintain ask us chat hours on the Primo homepage. We just want to link to the ask us page.
- We need to align the homepage text with the new names for the search scopes

### How this addresses that need:
- Removes ask us chat hours from the homepage content, keeps link to ask us page.
- updates text explaining how to limit to library materials by choosing a particular search scope
- updates some special characters

### Side effects of this change:
none

### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ES-3572
