### PR TITLE
Prevent login request from being proxied to local server

### DIFF
--- a/proxy/proxy.conf.mjs
+++ b/proxy/proxy.conf.mjs
@@ -9,6 +9,16 @@ import {deepMerge} from "./proxy-utils.mjs";
 
 const proxyRules = [
   {
+    // redirect external login requests
+    context: ["/primaws/suprimaExtLogin"],
+    target: PROXY_TARGET,
+    changeOrigin: true,
+    followRedirects: true,
+    onProxyReq(_proxyReq, req, res) {
+      res.writeHead(302, { location: PROXY_TARGET + req.url });
+    },
+  },
+  {
     context: [
       '/custom/*/assets',
       '/custom/*/assets/**',


### PR DESCRIPTION
### Why these changes are being introduced:
Developers need to be able to log into Primo while using the proxy configurations in the NDE development environment. The proxy configuration was redirecting login requests to the local server instead of the Primo server, which was preventing developers from logging in. This change prevents login requests from being proxied to the local server.

### How this addresses that need:
added a new proxy rule to redirect login requests to the Primo server instead of the local server.

