### PR TITLE
Bugfix to visually cropped link

### DIFF
--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -722,15 +722,22 @@ mat-expansion-panel nde-general-electronic-service-link {
     a {
         @include underlinedLinks;
         font-weight: 400 !important;
+        display: inline-block;
+        line-height: 1.4;
 
         span {
             text-decoration: underline !important;
             text-decoration-color: $color-blue-500 !important;
             height: 22px;
+            overflow: visible !important;
         }
 
         mat-icon {
             display: none !important;
+        }
+
+        &.display-flex {
+            display: inline !important;
         }
     }
 }


### PR DESCRIPTION
### Why these changes are being introduced
After a recent PR was merged we noticed that a link was visually cropped on smaller screens.

### How this addresses that need
This work removes the `overflow: hidden` that was causing the truncation and tries to make the fully visible link as presentable as possible given the constraints of the column it's in.

This can be observed on the item (partial link):
/nde/fulldisplay?context=L&vid=01MIT_INST:NDE&search_scope=all&lang=en&docid=alma990002935920106761

This was a followup from this PR:
https://github.com/MITLibraries/Primo-NDE-Customization-Package/pull/64