### PR TITLE
Add custom Request card component

### DIFF
--- a/src/app/custom1-module/customComponentMappings.ts
+++ b/src/app/custom1-module/customComponentMappings.ts
@@ -1,8 +1,9 @@
 import { PrimoBrandedNameComponent } from '../primo-branded-name/primo-branded-name.component';
 import { NoResultsComponent } from '../no-results/no-results.component';
-
+import { MitRequestCardComponent } from '../mit-request-card/mit-request-card.component';
 // Define the map
 export const selectorComponentMap = new Map<string, any>([
   ['nde-search-no-results', NoResultsComponent],
   ['nde-logo-after', PrimoBrandedNameComponent],
+  ['nde-request-card-after', MitRequestCardComponent],
 ]);

--- a/src/app/mit-request-card/mit-request-card.component.html
+++ b/src/app/mit-request-card/mit-request-card.component.html
@@ -1,0 +1,25 @@
+<mat-card class="request-card custom-request-card clickable-card"
+          (click)="handleCardClick()"
+          role="button"
+          tabindex="0"
+          (keyup.enter)="handleCardClick()"
+          (keyup.space)="handleCardClick()">
+  <mat-card-content class="column-for-requests-container">
+    <div class="left-section">
+      <div class="request-card-icon-title-subtitle">
+       
+          <mat-icon class="nde-mat-icon-size-large">
+          </mat-icon>
+       
+        <div class="request-card-title-subtitle">
+          <div class="request-title mat-body-large">
+            {{ (host.requestService?.serviceTitle ?? '' | translate) }}
+          </div>
+          <span class="request-description mat-body-medium"
+            [innerHTML]="(serviceDescription | translate)">
+          </span>
+        </div>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/src/app/mit-request-card/mit-request-card.component.html
+++ b/src/app/mit-request-card/mit-request-card.component.html
@@ -1,9 +1,9 @@
 <mat-card class="request-card custom-request-card clickable-card"
-          (click)="handleCardClick()"
+          (click)="handleCardClick($event)"
           role="button"
           tabindex="0"
-          (keyup.enter)="handleCardClick()"
-          (keyup.space)="handleCardClick()">
+          (keydown.enter)="handleCardClick($event)"
+          (keydown.space)="$event.preventDefault(); handleCardClick($event)">
   <mat-card-content class="column-for-requests-container">
     <div class="left-section">
       <div class="request-card-icon-title-subtitle">
@@ -13,7 +13,7 @@
        
         <div class="request-card-title-subtitle">
           <div class="request-title mat-body-large">
-            {{ (host.requestService?.serviceTitle ?? '' | translate) }}
+            {{ (host.requestService?.serviceTitle ?? '') | translate }}
           </div>
           <span class="request-description mat-body-medium"
             [innerHTML]="(serviceDescription | translate)">

--- a/src/app/mit-request-card/mit-request-card.component.scss
+++ b/src/app/mit-request-card/mit-request-card.component.scss
@@ -24,13 +24,6 @@
 
   }
 
-  mat-icon svg {
-    border: 1px solid red !important;
-  }  
-
-  .column-for-icon {
-    flex-shrink: 0;
-  }  
 
   .request-title {
     font-weight: 500;

--- a/src/app/mit-request-card/mit-request-card.component.scss
+++ b/src/app/mit-request-card/mit-request-card.component.scss
@@ -1,0 +1,29 @@
+.clickable-card {
+  margin-top: 30px;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  }
+
+
+  &:focus {
+    outline: 2px solid black;
+    outline-offset: 2px;
+  }
+
+  &:focus-visible {
+    outline: 2px solid black;
+    outline-offset: 2px;
+  }
+.request-card-icon-title-subtitle {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.column-for-icon {
+  flex-shrink: 0;
+}  
+}

--- a/src/app/mit-request-card/mit-request-card.component.scss
+++ b/src/app/mit-request-card/mit-request-card.component.scss
@@ -20,8 +20,6 @@
     display: flex;
     align-items: center;
     gap: 16px;
-
-
   }
 
 
@@ -33,3 +31,4 @@
    stroke: var(--sys-primary);
   }
 }
+::ng-deep nde-request-card { display: none; }

--- a/src/app/mit-request-card/mit-request-card.component.scss
+++ b/src/app/mit-request-card/mit-request-card.component.scss
@@ -1,29 +1,42 @@
 .clickable-card {
   margin-top: 30px;
   cursor: pointer;
-  transition: box-shadow 0.2s ease;
+  border-radius: 0;
+  border: 1px solid #0000FF;
+  background-color: #fff;
+  box-shadow: none;
 
   &:hover {
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    background-color: #F0F0FF;
+    color: #0000FF;
   }
 
-
-  &:focus {
+  &:focus-visible, &:focus {
     outline: 2px solid black;
     outline-offset: 2px;
   }
 
-  &:focus-visible {
-    outline: 2px solid black;
-    outline-offset: 2px;
-  }
-.request-card-icon-title-subtitle {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
+  .request-card-icon-title-subtitle {
+    display: flex;
+    align-items: center;
+    gap: 16px;
 
-.column-for-icon {
-  flex-shrink: 0;
-}  
+
+  }
+
+  mat-icon svg {
+    border: 1px solid red !important;
+  }  
+
+  .column-for-icon {
+    flex-shrink: 0;
+  }  
+
+  .request-title {
+    font-weight: 500;
+  }
+
+  ::ng-deep mat-icon svg path {
+   stroke: var(--sys-primary);
+  }
 }

--- a/src/app/mit-request-card/mit-request-card.component.spec.ts
+++ b/src/app/mit-request-card/mit-request-card.component.spec.ts
@@ -1,0 +1,159 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { MitRequestCardComponent } from './mit-request-card.component';
+
+describe('MitRequestCardComponent', () => {
+  let component: MitRequestCardComponent;
+  let fixture: ComponentFixture<MitRequestCardComponent>;
+
+  // TranslateModule is required because the template uses the translate pipe.
+  // fixture.detectChanges() is omitted from the outer beforeEach so each
+  // describe block controls when ngOnInit fires: handleCardClick tests call
+  // methods directly, extractSvgFromHost tests call detectChanges() themselves.
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MitRequestCardComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MitRequestCardComponent);
+    component = fixture.componentInstance;
+    // Provide a minimal hostComponent so the component does not throw
+    // if anything accesses host properties before a test sets its own mock.
+    (component as any).hostComponent = {
+      requestService: {
+        iconName: 'test-icon',
+        serviceTitle: 'Test Service',
+        serviceDescription: 'Test Description',
+      },
+    };
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // handleCardClick delegates to host component methods depending on whether
+  // the request is a GES (General Electronic Service) request or not.
+  describe('handleCardClick', () => {
+    let mockHost: jasmine.SpyObj<{
+      isNotGES(): boolean;
+      handleRequestBtnClick(): void;
+      getLinkForGesOrResourceSharing(): string;
+      sendAnalytics(): void;
+    }>;
+
+    // A spy object gives us all four host methods as trackable spies.
+    // getLinkForGesOrResourceSharing defaults to a valid URL; GES tests spy on
+    // window.open in their own beforeEach to prevent real tabs from opening.
+    beforeEach(() => {
+      mockHost = jasmine.createSpyObj('mockHost', [
+        'isNotGES',
+        'handleRequestBtnClick',
+        'getLinkForGesOrResourceSharing',
+        'sendAnalytics',
+      ]);
+      mockHost.getLinkForGesOrResourceSharing.and.returnValue(
+        'http://example.com',
+      );
+      (component as any).hostComponent = mockHost;
+    });
+
+    // Non-GES requests (Physical item requests) are handled by the host
+    // component's own handleRequestBtnClick method.
+    describe('when isNotGES returns true (non-GES request)', () => {
+      beforeEach(() => mockHost.isNotGES.and.returnValue(true));
+
+      it('should call handleRequestBtnClick', () => {
+        component.handleCardClick();
+        expect(mockHost.handleRequestBtnClick).toHaveBeenCalled();
+      });
+
+      it('should not call getLinkForGesOrResourceSharing', () => {
+        component.handleCardClick();
+        expect(mockHost.getLinkForGesOrResourceSharing).not.toHaveBeenCalled();
+      });
+
+      it('should not call sendAnalytics', () => {
+        component.handleCardClick();
+        expect(mockHost.sendAnalytics).not.toHaveBeenCalled();
+      });
+    });
+
+    // GES (General Electronic Service) requests get a link and fire an analytics event.
+    describe('when isNotGES returns false (GES request)', () => {
+      beforeEach(() => {
+        mockHost.isNotGES.and.returnValue(false);
+        // Prevent real browser tabs opening — the default mock returns a valid
+        // URL which would otherwise trigger window.open on every test here.
+        spyOn(window, 'open');
+      });
+
+      it('should call getLinkForGesOrResourceSharing', () => {
+        component.handleCardClick();
+        expect(mockHost.getLinkForGesOrResourceSharing).toHaveBeenCalled();
+      });
+
+      it('should call sendAnalytics', () => {
+        component.handleCardClick();
+        expect(mockHost.sendAnalytics).toHaveBeenCalled();
+      });
+
+      it('should not call handleRequestBtnClick', () => {
+        component.handleCardClick();
+        expect(mockHost.handleRequestBtnClick).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should not throw when host is undefined', () => {
+      // The component uses optional chaining throughout handleCardClick,
+      // so a missing hostComponent should degrade gracefully rather than throw.
+      (component as any).hostComponent = undefined;
+      expect(() => component.handleCardClick()).not.toThrow();
+    });
+  });
+
+  // extractSvgFromHost runs during ngOnInit and clones the SVG from the NDE
+  // host component's mat-icon into this component's own placeholder span.
+  // Tests drive it through fixture.detectChanges() so the real @ViewChild
+  // reference is used and the outcome is verified in the rendered DOM.
+  describe('extractSvgFromHost', () => {
+    let mockHostElement: HTMLDivElement;
+
+    beforeEach(() => {
+      // Insert mockHostElement immediately before the fixture's parent container
+      // so the component's DOM traversal (parentElement.previousElementSibling)
+      // resolves to our mock NDE host element when ngOnInit fires.
+      mockHostElement = document.createElement('div');
+      const container = fixture.nativeElement.parentElement;
+      container.parentElement!.insertBefore(mockHostElement, container);
+
+      // Simulate the NDE host's rendered mat-icon with an SVG inside.
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('viewBox', '0 0 24 24');
+      const hostMatIcon = document.createElement('mat-icon');
+      hostMatIcon.setAttribute('data-mat-icon-name', 'test-icon');
+      hostMatIcon.appendChild(svg);
+      mockHostElement.appendChild(hostMatIcon);
+    });
+
+    afterEach(() => {
+      mockHostElement.remove();
+    });
+
+    it('should clone the host SVG into the mat-icon placeholder on init', () => {
+      fixture.detectChanges(); // triggers ngOnInit → extractSvgFromHost
+
+      const clonedSvg = fixture.nativeElement.querySelector('mat-icon svg');
+      expect(clonedSvg).toBeTruthy();
+      expect(clonedSvg.getAttribute('viewBox')).toBe('0 0 24 24');
+    });
+
+    it('should not remove the original SVG from the host on init', () => {
+      // Verifies cloneNode is used rather than moving the node.
+      const originalSvg = mockHostElement.querySelector('svg')!;
+      fixture.detectChanges();
+      expect(mockHostElement.querySelector('svg')).toBe(originalSvg);
+    });
+  });
+});

--- a/src/app/mit-request-card/mit-request-card.component.ts
+++ b/src/app/mit-request-card/mit-request-card.component.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
 import { MatIcon, MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -31,13 +30,7 @@ interface RequestCard {
 @Component({
   selector: 'custom-mit-request-card',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatCardModule,
-    MatButtonModule,
-    MatIconModule,
-    TranslateModule,
-  ],
+  imports: [CommonModule, MatCardModule, MatIconModule, TranslateModule],
   templateUrl: './mit-request-card.component.html',
   styleUrl: './mit-request-card.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -105,17 +98,19 @@ export class MitRequestCardComponent implements OnInit {
     this.hostIcon.nativeElement.appendChild(svgClone);
   }
   // use the host component's methods to handle the click event
-  handleCardClick(): void {
+  handleCardClick(event?: Event): void {
+    const target = event?.target as HTMLElement | null;
+    if (target?.closest?.('a, button, input, textarea, select')) return;
+
     if (this.host?.isNotGES?.()) {
       this.host.handleRequestBtnClick?.();
-    } else {
-      const link = this.host?.getLinkForGesOrResourceSharing?.();
-      // send analytics event for GES or Resource Sharing click
-      // the request form handles sending analytics for non-GES requests.
-      this.host?.sendAnalytics?.();
-      if (link) {
-        window.open(link, '_blank', 'noopener,noreferrer');
-      }
+      return;
     }
+
+    const link = this.host?.getLinkForGesOrResourceSharing?.();
+    // send analytics event for GES or Resource Sharing click
+    // the request form handles sending analytics for non-GES requests.
+    this.host?.sendAnalytics?.();
+    if (link) window.open(link, '_blank', 'noopener,noreferrer');
   }
 }

--- a/src/app/mit-request-card/mit-request-card.component.ts
+++ b/src/app/mit-request-card/mit-request-card.component.ts
@@ -1,0 +1,121 @@
+import {
+  Component,
+  Input,
+  ElementRef,
+  OnInit,
+  ViewChild,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon, MatIconModule } from '@angular/material/icon';
+import { TranslateModule } from '@ngx-translate/core';
+
+/**
+ * Contract for the host component properties and methods
+ * that the MitRequestCard component depends on
+ */
+interface RequestCard {
+  requestService?: {
+    iconName: string;
+    serviceTitle: string;
+    serviceDescription: string;
+  };
+  isNotGES?(): boolean;
+  handleRequestBtnClick?(): void;
+  getLinkForGesOrResourceSharing?(): string;
+  sendAnalytics?(): void;
+}
+
+@Component({
+  selector: 'custom-mit-request-card',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    TranslateModule,
+  ],
+  templateUrl: './mit-request-card.component.html',
+  styleUrl: './mit-request-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MitRequestCardComponent implements OnInit {
+  @Input() private hostComponent!: RequestCard;
+  @ViewChild(MatIcon, { read: ElementRef, static: true })
+  private hostIcon!: ElementRef<HTMLElement>;
+
+  constructor(private elementRef: ElementRef) {}
+
+  get host() {
+    return this.hostComponent;
+  }
+
+  // Getter for serviceDescription so we can handle cases where service description might
+  // contain HTML content and we want to bind it safely in the template.
+  get serviceDescription(): string {
+    const desc = this.host?.requestService?.serviceDescription ?? '';
+    return desc;
+  }
+
+  ngOnInit() {
+    this.extractSvgFromHost();
+  }
+
+  // The OOTB NDE template for this component uses a custom directive *ndeIcon which is not available to this custom component.
+  // As an alternative, we can extract the SVG from the host component's mat-icon and insert it into this component's mat-icon.
+  private extractSvgFromHost() {
+    // Get the icon name from the host's requestService property.
+    const iconName = this.host?.requestService?.iconName;
+    if (!iconName) {
+      console.error('Icon name not available from host');
+      return;
+    }
+
+    // Get this component's native element to use as a reference for finding the host component
+    const customComponent = this.elementRef.nativeElement;
+
+    // Find the host component (previous sibling or ancestor) where we'll get the icon SVG from.
+    // This assumes that the host component is the previous sibling of this custom component in the DOM.
+    // which is how this is mapped in customComponentMappings.ts i.e. 'nde-request-card-after'
+    let hostElement = customComponent.parentElement?.previousElementSibling;
+
+    if (!hostElement) {
+      console.error('Host element not found');
+      return;
+    }
+
+    // Find the host's rendered mat-icon with the matching icon name
+    const hostSvg = hostElement.querySelector(
+      `mat-icon[data-mat-icon-name="${iconName}"] svg`,
+    );
+
+    if (!hostSvg) {
+      console.error(
+        'could not retrieve svg from host matching icon name:',
+        iconName,
+      );
+      return;
+    }
+
+    // Clone and insert the SVG into the placeholder
+    const svgClone = hostSvg.cloneNode(true) as Node;
+    this.hostIcon.nativeElement.appendChild(svgClone);
+  }
+  // use the host component's methods to handle the click event
+  handleCardClick(): void {
+    if (this.host?.isNotGES?.()) {
+      this.host.handleRequestBtnClick?.();
+    } else {
+      const link = this.host?.getLinkForGesOrResourceSharing?.();
+      // send analytics event for GES or Resource Sharing click
+      // the request form handles sending analytics for non-GES requests.
+      this.host?.sendAnalytics?.();
+      if (link) {
+        window.open(link, '_blank', 'noopener,noreferrer');
+      }
+    }
+  }
+}

--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -282,6 +282,9 @@ nde-logo {
     }
 }
 
+nde-request-card {
+    display: none !important;
+}
 
 // Header styles
 header.top-bar {

--- a/src/app/styles/mit-theme.scss
+++ b/src/app/styles/mit-theme.scss
@@ -282,10 +282,6 @@ nde-logo {
     }
 }
 
-nde-request-card {
-    display: none !important;
-}
-
 // Header styles
 header.top-bar {
 


### PR DESCRIPTION
### Why these changes are being introduced:
We wanted to change how the request card component displays
so that the entire card is clickable rather than
having a separate button inside the card for the request action.

### How this addresses that need:
Adds a new custom request card component to replace the original.

This new component receives an instance of the original request card component.

The original request card component's properties are passed to the new component's template and calls the parent component's methods to
handle the request actions.

### Side effects of this change

Changes to the original request card component's properties and methods may prevent this component from displaying properly. 

### Relevant ticket(s)

https://mitlibraries.atlassian.net/browse/NDE-155
